### PR TITLE
Improvement: Use a UUID for configuration of names and password

### DIFF
--- a/vars/buildTestMySQLDatabase.groovy
+++ b/vars/buildTestMySQLDatabase.groovy
@@ -7,6 +7,7 @@
         dbName:    The name of the database to create. Default: "testdb_${env.BUILD_NUMBER}"
         dbUser:    The name of the database user to create the database with.
         dbPass:    The password of the database user.
+        newDB:      Boolean value to setup a new DB. Default: true.
     
     Returns the name of the created database as well as test user credentials in a Map.
         Map Keys:
@@ -16,7 +17,14 @@
 */
 String call(body) {
     def config = evaluateMySQLDatabaseConfiguration(body)
-    
+    // Create a unique id to use for database names and user accounts.
+    String uuid = UUID.randomUUID()
+    config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
+    // Store UUID into a Jenkins environment variable.
+    if (env.MYSQL_UUID == null || env.MYSQL_UUID == '' || config.newDB == true) {
+        env.MYSQL_UUID = config.uuid
+    }
+
     // Create the test database
     def createdDatabaseName = createMySQLDatabase {
         mysqlPath = config.mysqlPath

--- a/vars/buildTestMySQLDatabase.groovy
+++ b/vars/buildTestMySQLDatabase.groovy
@@ -15,15 +15,15 @@
             testUsername:     The username of the test user
             testUserPassword: The password of the test user
 */
-String call(body) {
-    def config = evaluateMySQLDatabaseConfiguration(body)
+String call(Boolean newDB = true,  Closure body) {
     // Create a unique id to use for database names and user accounts.
     String uuid = UUID.randomUUID()
     config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
     // Store UUID into a Jenkins environment variable.
-    if (env.MYSQL_UUID == null || env.MYSQL_UUID == '' || config.newDB == true) {
+    if (env.MYSQL_UUID == null || env.MYSQL_UUID == '' || newDB == true) {
         env.MYSQL_UUID = config.uuid
     }
+    def config = evaluateMySQLDatabaseConfiguration(body)
 
     // Create the test database
     def createdDatabaseName = createMySQLDatabase {

--- a/vars/buildTestMySQLDatabase.groovy
+++ b/vars/buildTestMySQLDatabase.groovy
@@ -16,12 +16,12 @@
             testUserPassword: The password of the test user
 */
 String call(Boolean newDB = true,  Closure body) {
-    // Create a unique id to use for database names and user accounts.
-    String uuid = UUID.randomUUID()
-    config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
     // Store UUID into a Jenkins environment variable.
     if (env.MYSQL_UUID == null || env.MYSQL_UUID == '' || newDB == true) {
-        env.MYSQL_UUID = config.uuid
+        // Create a unique id to use for database names and user accounts.
+        String uuid = UUID.randomUUID()
+        uuidconstruct = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
+        env.MYSQL_UUID = uuidconstruct
     }
     def config = evaluateMySQLDatabaseConfiguration(body)
 

--- a/vars/createTestMySQLUser.groovy
+++ b/vars/createTestMySQLUser.groovy
@@ -15,7 +15,8 @@
 */
 def call(Closure body) {
     def config = evaluateMySQLDatabaseConfiguration(body)
-    
+
+    echo "MYSQL TEST UUID: ${env.MYSQL_UUID}"
     // Define the test user parameters here
     String test_username = "testdb_user_${config.uuid}"
     def test_user = test_username.take(32)

--- a/vars/createTestMySQLUser.groovy
+++ b/vars/createTestMySQLUser.groovy
@@ -17,8 +17,8 @@ def call(Closure body) {
     def config = evaluateMySQLDatabaseConfiguration(body)
     
     // Define the test user parameters here
-    def test_user = "testdb_user_${env.BUILD_NUMBER}"
-    def test_user_pwd = "testdb_password_${env.BUILD_NUMBER}"
+    def test_user = "testdb_user_${config.uuid}"
+    def test_user_pwd = "testdb_password_${config.uuid}"
     
     // Run shell commands to create the user here
     def CREATE_SQL = "CREATE USER '${test_user}'@'%' IDENTIFIED BY '${test_user_pwd}';" +

--- a/vars/createTestMySQLUser.groovy
+++ b/vars/createTestMySQLUser.groovy
@@ -17,7 +17,8 @@ def call(Closure body) {
     def config = evaluateMySQLDatabaseConfiguration(body)
     
     // Define the test user parameters here
-    def test_user = "testdb_user_${config.uuid}"
+    String test_username = "testdb_user_${config.uuid}"
+    def test_user = test_username.take(32)
     def test_user_pwd = "testdb_password_${config.uuid}"
     
     // Run shell commands to create the user here

--- a/vars/createTestMySQLUser.groovy
+++ b/vars/createTestMySQLUser.groovy
@@ -18,7 +18,7 @@ def call(Closure body) {
 
     // Define the test user parameters here
     String test_username = "testdb_user_${env.MYSQL_UUID}"
-    def test_user = test_username.take(32)
+    def test_user = test_username.take(30)
     def test_user_pwd = "testdb_password_${env.MYSQL_UUID}"
     
     // Run shell commands to create the user here

--- a/vars/createTestMySQLUser.groovy
+++ b/vars/createTestMySQLUser.groovy
@@ -16,11 +16,10 @@
 def call(Closure body) {
     def config = evaluateMySQLDatabaseConfiguration(body)
 
-    echo "MYSQL TEST UUID: ${env.MYSQL_UUID}"
     // Define the test user parameters here
-    String test_username = "testdb_user_${config.uuid}"
+    String test_username = "testdb_user_${env.MYSQL_UUID}"
     def test_user = test_username.take(32)
-    def test_user_pwd = "testdb_password_${config.uuid}"
+    def test_user_pwd = "testdb_password_${env.MYSQL_UUID}"
     
     // Run shell commands to create the user here
     def CREATE_SQL = "CREATE USER '${test_user}'@'%' IDENTIFIED BY '${test_user_pwd}';" +

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -9,10 +9,6 @@
         dbPassword:    The password of the database user.
 */
 def call(String dbUserName, String dbPassword, String dbSchemaName, String mysqlPath = '', String mysqlPort = '') {
-    echo "====================================== Debug ======================================================="
-    echo "DB User: ${dbUserName}"
-    echo "DB Pass: ${dbPassword}"
-    echo "DB Name: ${dbSchemaName}"
     
     // Destroy the test database
     dropMySQLDatabase(dbUserName, dbPassword, dbSchemaName)

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -9,6 +9,10 @@
         dbPass:    The password of the database user.
 */
 def call(String dbUser, String dbPass, String dbName, String mysqlPath = '', String mysqlPort = '') {
+    echo "====================================== Debug ======================================================="
+    echo "DB User: ${dbUser}"
+    echo "DB Pass: ${dbPass}"
+    echo "DB Name: ${dbName}"
     def body = {
         mysqlPath = mysqlPath
         mysqlPort = mysqlPort

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -8,7 +8,7 @@
         dbUser:    The name of the database user to destroy the database with.
         dbPass:    The password of the database user.
 */
-def call(String mysqlPath, String mysqlPort, String dbName, String dbUser, String dbPass) {
+def call(String dbUser, String dbPass, String dbName, String mysqlPath = '', String mysqlPort = '') {
     def body = {
         mysqlPath = mysqlPath
         mysqlPort = mysqlPort

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -25,5 +25,6 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String mysql
     dropMySQLDatabase(dbUserName, dbPassword, dbSchemaName)
 
     // Destroy the test user
-    dropTestMySQLUser(body)
-}
+    dropTestMySQLUser(dbUserName, dbPassword, dbSchemaName)
+
+    }

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -8,11 +8,11 @@
         dbUserName:    The name of the database user to destroy the database with.
         dbPassword:    The password of the database user.
 */
-def call(String dbUserName, String dbPassword, String dbSchemaName, String mysqlPath = '', String mysqlPort = '') {
+def call(String dbUserName, String dbPassword, String dbSchemaName, String dbUserNameDrop = '', String mysqlPath = '', String mysqlPort = '') {
     
     // Destroy the test database
     dropMySQLDatabase(dbUserName, dbPassword, dbSchemaName)
 
     // Destroy the test user
-    dropTestMySQLUser(dbUserName, dbPassword, dbSchemaName)
+    dropTestMySQLUser(dbUserName, dbPassword, dbUserNameDrop)
     }

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -16,9 +16,9 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String mysql
     def body = {
         mysqlPath = mysqlPath
         mysqlPort = mysqlPort
-        dbName = dbSchemaName
-        dbUser = dbUserName
-        dbPass = dbPassword
+        dbSchemaName = dbName
+        dbUserName = dbUser
+        dbPassword = dbPass
     }
     
     // Destroy the test database

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -13,18 +13,10 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String mysql
     echo "DB User: ${dbUserName}"
     echo "DB Pass: ${dbPassword}"
     echo "DB Name: ${dbSchemaName}"
-    def body = {
-        mysqlPath = mysqlPath
-        mysqlPort = mysqlPort
-        dbSchemaName = dbName
-        dbUserName = dbUser
-        dbPassword = dbPass
-    }
     
     // Destroy the test database
     dropMySQLDatabase(dbUserName, dbPassword, dbSchemaName)
 
     // Destroy the test user
     dropTestMySQLUser(dbUserName, dbPassword, dbSchemaName)
-
     }

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -22,8 +22,8 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String mysql
     }
     
     // Destroy the test database
-    dropMySQLDatabase(body)
-    
+    dropMySQLDatabase(dbUserName, dbPassword, dbSchemaName)
+
     // Destroy the test user
     dropTestMySQLUser(body)
 }

--- a/vars/destroyTestMySQLDatabase.groovy
+++ b/vars/destroyTestMySQLDatabase.groovy
@@ -4,21 +4,21 @@
     Accepted Parameters:
         mysqlPath: The system path to the MySQL binary. Default: /usr/bin/mysql
         mysqlPort: The port to use to connect to MySQL. Default: 3306
-        dbName:    The name of the database to destroy. Default: "testdb_${env.BUILD_NUMBER}"
-        dbUser:    The name of the database user to destroy the database with.
-        dbPass:    The password of the database user.
+        dbSchemaName:    The name of the database to destroy. Default: "testdb_${env.BUILD_NUMBER}"
+        dbUserName:    The name of the database user to destroy the database with.
+        dbPassword:    The password of the database user.
 */
-def call(String dbUser, String dbPass, String dbName, String mysqlPath = '', String mysqlPort = '') {
+def call(String dbUserName, String dbPassword, String dbSchemaName, String mysqlPath = '', String mysqlPort = '') {
     echo "====================================== Debug ======================================================="
-    echo "DB User: ${dbUser}"
-    echo "DB Pass: ${dbPass}"
-    echo "DB Name: ${dbName}"
+    echo "DB User: ${dbUserName}"
+    echo "DB Pass: ${dbPassword}"
+    echo "DB Name: ${dbSchemaName}"
     def body = {
         mysqlPath = mysqlPath
         mysqlPort = mysqlPort
-        dbName = dbName
-        dbUser = dbUser
-        dbPass = dbPass
+        dbName = dbSchemaName
+        dbUser = dbUserName
+        dbPass = dbPassword
     }
     
     // Destroy the test database

--- a/vars/dropMySQLDatabase.groovy
+++ b/vars/dropMySQLDatabase.groovy
@@ -18,6 +18,6 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String mysql
     def dropconfig = evaluateMySQLConfiguration(configuration)
     // Run shell commands to drop the database here
     def DROP_SQL = "DROP DATABASE IF EXISTS ${dbSchemaName};"
-    def SHELL_CMD = "\"${mysqlPath}\" -u \"${dbUserName}\" --password=\"${dbPassword}\" <<-EOF\n${DROP_SQL}\nEOF"
+    def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
     sh "${SHELL_CMD}"
 }

--- a/vars/dropMySQLDatabase.groovy
+++ b/vars/dropMySQLDatabase.groovy
@@ -4,15 +4,20 @@
     Accepted Parameters:
         mysqlPath: The system path to the MySQL binary. Default: /usr/bin/mysql
         mysqlPort: The port to use to connect to MySQL. Default: 3306
-        dbName:    The name of the database to drop. Default: "testdb_${env.BUILD_NUMBER}"
-        dbUser:    The name of the database user to drop the database with.
-        dbPass:    The password of the database user.
+        dbSchemaName:    The name of the database to drop. Default: "testdb_${env.BUILD_NUMBER}"
+        dbUserName:    The name of the database user to drop the database with.
+        dbPassword:    The password of the database user.
 */
-def call(Closure body) {
-    def config = evaluateMySQLDatabaseConfiguration(body)
-    
+def call(String dbUserName, String dbPassword, String dbSchemaName, String mysqlPath = '', String mysqlPort = '') {
+    configuration = [:]
+    configuration.dbUser = dbUserName
+    configuration.dbPass = dbPassword
+    configuration.dbName = dbSchemaName
+    configuration.mysqlPath = mysqlPath
+    configuration.mysqlPort = mysqlPort
+    def dropconfig = evaluateMySQLConfiguration(configuration)
     // Run shell commands to drop the database here
-    def DROP_SQL = "DROP DATABASE IF EXISTS ${config.dbName};"
-    def SHELL_CMD = "\"${config.mysqlPath}\" -u \"${config.dbUser}\" --password=\"${config.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
+    def DROP_SQL = "DROP DATABASE IF EXISTS ${dbSchemaName};"
+    def SHELL_CMD = "\"${mysqlPath}\" -u \"${dbUserName}\" --password=\"${dbPassword}\" <<-EOF\n${DROP_SQL}\nEOF"
     sh "${SHELL_CMD}"
 }

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -28,9 +28,9 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     // Run shell commands to drop the user here
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%'; REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'localhost';"
     def FLUSH = "FLUSH PRIVILEGES;"
-    def SHELL_CMD2 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${REVOKE_SQL}${FLUSH}\nEOF"
-    sh "${SHELL_CMD2}"
-    def DROP_SQL = "DROP USER '${test_user}'; DROP USER '${test_user}'@'localhost';"
-    def SHELL_CMD1 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
+    def SHELL_CMD1 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${REVOKE_SQL}${FLUSH}\nEOF"
     sh "${SHELL_CMD1}"
+    def DROP_SQL = "DROP USER '${test_user}'; DROP USER '${test_user}'@'localhost';"
+    def SHELL_CMD2 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
+    sh "${SHELL_CMD2}"
 }

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -22,7 +22,7 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     if (dbDropUserName.isEmpty()) {
         // Define the test user parameters here
         String test_username = "testdb_user_${env.MYSQL_UUID}"
-        test_user = test_username.take(32)
+        test_user = test_username.take(30)
     }
 
     // Run shell commands to drop the user here

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -11,10 +11,11 @@
 */
 def call(Closure body) {
     def config = evaluateMySQLDatabaseConfiguration(body)
-    
-    // Define the test user parameters here
-    def test_user = config.testUser ?: "testdb_user_${env.BUILD_NUMBER}"
-    
+    if (config.testUser == null || config.testUser == '') {
+        // Define the test user parameters here
+        String test_username = "testdb_user_${env.MYSQL_UUID}"
+        def test_user = test_username.take(32)
+    }
     // Run shell commands to drop the user here
     def DROP_SQL = "DROP USER '${test_user}'@'%';"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%';" +

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -26,14 +26,11 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     }
 
     // Run shell commands to drop the user here
+    def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%'; REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'localhost';"
+    def FLUSH = "FLUSH PRIVILEGES;"
+    def SHELL_CMD2 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${REVOKE_SQL}${FLUSH}\nEOF"
+    sh "${SHELL_CMD2}"
     def DROP_SQL = "DROP USER '${test_user}'; DROP USER '${test_user}'@'localhost';"
-    echo "=============================== DEBUG ======================================"
-    echo DROP_SQL
-    echo "=============================== /DEBUG ======================================"
     def SHELL_CMD1 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
     sh "${SHELL_CMD1}"
-    def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}';"
-    def FLUSH = "FLUSH PRIVILEGES;"
-    def SHELL_CMD2 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}${FLUSH}\nEOF"
-    sh "${SHELL_CMD2}"
 }

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -9,12 +9,11 @@
         testUser:  The username of the test user to be dropped. Default: "testdb_user_${env.BUILD_NUMBER}"
         
 */
-def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDropUserName = '', String mysqlPath = '', String mysqlPort = '') {
+def call(String dbUserName, String dbPassword, String dbDropUserName = '', String mysqlPath = '', String mysqlPort = '') {
 
     configuration = [:]
     configuration.dbUser = dbUserName
     configuration.dbPass = dbPassword
-    configuration.dbName = dbSchemaName
     configuration.mysqlPath = mysqlPath
     configuration.mysqlPort = mysqlPort
     def dropconfig = evaluateMySQLConfiguration(configuration)

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -26,7 +26,7 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     }
 
     // Run shell commands to drop the user here
-    def DROP_SQL = "DROP USER '${test_user}'@'%';"
+    def DROP_SQL = "DROP USER '${test_user};"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%';" +
         "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'localhost';"
     def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}\nEOF"

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -23,6 +23,10 @@ def call(String dbUserName, String dbPassword, String dbDropUserName = '', Strin
         String test_username = "testdb_user_${env.MYSQL_UUID}"
         test_user = test_username.take(30)
     }
+    else
+    {
+        test_user = dbDropUserName
+    }
 
     // Run shell commands to drop the user here
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%'; REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'localhost';"

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -18,7 +18,9 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     configuration.mysqlPath = mysqlPath
     configuration.mysqlPort = mysqlPort
     def dropconfig = evaluateMySQLConfiguration(configuration)
-
+    echo "====================================== Debug ======================================================="
+    echo "Username to drop: ${dbDropUserName}"
+    echo "====================================== /Debug ======================================================="
     if (dbDropUserName == null || dbDropUserName == '') {
         // Define the test user parameters here
         String test_username = "testdb_user_${env.MYSQL_UUID}"

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -9,9 +9,17 @@
         testUser:  The username of the test user to be dropped. Default: "testdb_user_${env.BUILD_NUMBER}"
         
 */
-def call(Closure body) {
-    def config = evaluateMySQLDatabaseConfiguration(body)
-    if (config.testUser == null || config.testUser == '') {
+def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDropUserName = '', String mysqlPath = '', String mysqlPort = '') {
+
+    configuration = [:]
+    configuration.dbUser = dbUserName
+    configuration.dbPass = dbPassword
+    configuration.dbName = dbSchemaName
+    configuration.mysqlPath = mysqlPath
+    configuration.mysqlPort = mysqlPort
+    def dropconfig = evaluateMySQLConfiguration(configuration)
+
+    if (dbDropUserName == null || dbDropUserName == '') {
         // Define the test user parameters here
         String test_username = "testdb_user_${env.MYSQL_UUID}"
         def test_user = test_username.take(32)
@@ -20,6 +28,6 @@ def call(Closure body) {
     def DROP_SQL = "DROP USER '${test_user}'@'%';"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%';" +
         "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'localhost';"
-    def SHELL_CMD = "\"${config.mysqlPath}\" -u \"${config.dbUser}\" --password=\"${config.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}\nEOF"
+    def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}\nEOF"
     sh "${SHELL_CMD}"
 }

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -26,7 +26,10 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     }
 
     // Run shell commands to drop the user here
-    def DROP_SQL = "DROP USER '${test_user}';DROP USER '${test_user}'@'localhost';"
+    def DROP_SQL = "DROP USER '${test_user}'; DROP USER '${test_user}'@'localhost';"
+    echo "=============================== DEBUG ======================================"
+    echo DROP_SQL
+    echo "=============================== /DEBUG ======================================"
     def SHELL_CMD1 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
     sh "${SHELL_CMD1}"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}';"

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -26,7 +26,7 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     }
 
     // Run shell commands to drop the user here
-    def DROP_SQL = "DROP USER '${test_user};"
+    def DROP_SQL = "DROP USER '${test_user}';DROP USER '${test_user}'@'localhost';"
     def SHELL_CMD1 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
     sh "${SHELL_CMD1}"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}';"

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -18,14 +18,13 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
     configuration.mysqlPath = mysqlPath
     configuration.mysqlPort = mysqlPort
     def dropconfig = evaluateMySQLConfiguration(configuration)
-    echo "====================================== Debug ======================================================="
-    echo "Username to drop: ${dbDropUserName}"
-    echo "====================================== /Debug ======================================================="
-    if (dbDropUserName == null || dbDropUserName == '') {
+
+    if (dbDropUserName.isEmpty()) {
         // Define the test user parameters here
         String test_username = "testdb_user_${env.MYSQL_UUID}"
-        def test_user = test_username.take(32)
+        test_user = test_username.take(32)
     }
+
     // Run shell commands to drop the user here
     def DROP_SQL = "DROP USER '${test_user}'@'%';"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%';" +

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -27,6 +27,8 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
 
     // Run shell commands to drop the user here
     def DROP_SQL = "DROP USER '${test_user};"
+    def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
+    sh "${SHELL_CMD}"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}';"
     def FLUSH = "FLUSH PRIVILEGES;"
     def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}${FLUSH}\nEOF"

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -27,10 +27,10 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
 
     // Run shell commands to drop the user here
     def DROP_SQL = "DROP USER '${test_user};"
-    def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
-    sh "${SHELL_CMD}"
+    def SHELL_CMD1 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}\nEOF"
+    sh "${SHELL_CMD1}"
     def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}';"
     def FLUSH = "FLUSH PRIVILEGES;"
-    def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}${FLUSH}\nEOF"
-    sh "${SHELL_CMD}"
+    def SHELL_CMD2 = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}${FLUSH}\nEOF"
+    sh "${SHELL_CMD2}"
 }

--- a/vars/dropTestMySQLUser.groovy
+++ b/vars/dropTestMySQLUser.groovy
@@ -27,8 +27,8 @@ def call(String dbUserName, String dbPassword, String dbSchemaName, String dbDro
 
     // Run shell commands to drop the user here
     def DROP_SQL = "DROP USER '${test_user};"
-    def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'%';" +
-        "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}'@'localhost';"
-    def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}\nEOF"
+    def REVOKE_SQL = "REVOKE ALL PRIVILEGES, GRANT OPTION FROM '${test_user}';"
+    def FLUSH = "FLUSH PRIVILEGES;"
+    def SHELL_CMD = "\"${dropconfig.mysqlPath}\" -u \"${dropconfig.dbUser}\" --password=\"${dropconfig.dbPass}\" <<-EOF\n${DROP_SQL}${REVOKE_SQL}${FLUSH}\nEOF"
     sh "${SHELL_CMD}"
 }

--- a/vars/evaluateMySQLConfiguration.groovy
+++ b/vars/evaluateMySQLConfiguration.groovy
@@ -1,0 +1,41 @@
+#!/usr/bin/env groovy
+
+/*
+    Evaluates a map of database configuration information.
+    
+    Accepted Parameters:
+        mysqlPath: The system path to the MySQL binary. Default: /usr/bin/mysql
+        mysqlPort: The port to use to connect to MySQL. Default: 3306
+        dbName:    The name of the database to use. Default: "testdb_${env.BUILD_NUMBER}"
+        dbUser:    The name of the database user to use. Required.
+        dbPass:    The password of the database user. Required.
+    
+    Returns the parsed database configuration object.
+*/
+def call(Map config) {
+    // Set any unprovided configuration values to defaults
+    // Set any unprovided configuration to random generated.
+    if (config.dbName == null || config.dbName == '') {
+        String dbNameConstructed = "testdb_" + env.MYSQL_UUID
+        config.dbName = dbNameConstructed
+    }
+
+    // Set newDB variable to true if not specified.
+    if (config.newDB == null | config.newDB == '') {
+        config.newDB = true
+    }
+
+    config.mysqlPath = config.mysqlPath ?: '/usr/bin/mysql'
+    config.mysqlPort = config.mysqlPort ?: 3306
+    
+    // Check that required, non-defaultable values are present
+    if (config.dbUser == null) {
+        error "Missing required parameter 'dbUser'"
+    }
+    if (config.dbPass == null) {
+        error "Missing required parameter 'dbPass'"
+    }
+    
+    // Return the parsed database configuration
+    return config
+}

--- a/vars/evaluateMySQLConfiguration.txt
+++ b/vars/evaluateMySQLConfiguration.txt
@@ -1,0 +1,23 @@
+<strong>evaluateMySQLDatabaseConfiguration {...}</strong>
+
+<p>
+    Evaluates a block/closure of database configuration information and converts it into an object.
+    
+    Accepted Parameters:
+        mysqlPath: The system path to the MySQL binary. Default: /usr/bin/mysql
+        mysqlPort: The port to use to connect to MySQL. Default: 3306
+        dbName:    The name of the database to use. Default: "testdb_${env.BUILD_NUMBER}"
+        dbUser:    The name of the database user to use. Required.
+        dbPass:    The password of the database user. Required.
+    
+    Returns the parsed database configuration object.
+    
+    <strong>Usage</strong>
+    def config = evaluateMySQLDatabaseConfiguration {
+        mysqlPath = '/usr/bin/mysql'
+        mysqlPort = 3306
+        dbName = 'random_test_db'
+        dbUser = 'db_user'
+        dbPass = 'db_password'
+    }
+</p>

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -23,7 +23,7 @@ def call(Closure body) {
 
     // Set any unprovided configuration values to defaults
     // Set any unprovided configuration to random generated.
-    if (dbName == null || dbName == '') {
+    if (config.dbName == null || config.dbName == '') {
         String dbNameConstructed = "testdb_" + modifieduuid + "_" + env.BUILD_NUMBER
         config.dbName = dbNameConstructed
     }

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -20,12 +20,13 @@ def call(Closure body) {
     body()
     String uuid = UUID.randomUUID()
     config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
-    env.MYSQL_UUID = config.uuid
-
+    if ( nv.MYSQL_UUID == null || env.MYSQL_UUID == '') {
+        env.MYSQL_UUID = config.uuid
+    }
     // Set any unprovided configuration values to defaults
     // Set any unprovided configuration to random generated.
     if (config.dbName == null || config.dbName == '') {
-        String dbNameConstructed = "testdb_" + config.uuid
+        String dbNameConstructed = "testdb_" + env.MYSQL_UUID
         config.dbName = dbNameConstructed
     }
     config.mysqlPath = config.mysqlPath ?: '/usr/bin/mysql'

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -20,7 +20,7 @@ def call(Closure body) {
     body()
     String uuid = UUID.randomUUID()
     config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
-    if ( nv.MYSQL_UUID == null || env.MYSQL_UUID == '') {
+    if (env.MYSQL_UUID == null || env.MYSQL_UUID == '') {
         env.MYSQL_UUID = config.uuid
     }
     // Set any unprovided configuration values to defaults

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -19,12 +19,12 @@ def call(Closure body) {
     body.delegate = config
     body()
     String uuid = UUID.randomUUID()
-    config.uuid  = uuid.replaceAll('-','_')
+    config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
 
     // Set any unprovided configuration values to defaults
     // Set any unprovided configuration to random generated.
     if (config.dbName == null || config.dbName == '') {
-        String dbNameConstructed = "testdb_" + config.uuid + "_" + env.BUILD_NUMBER
+        String dbNameConstructed = "testdb_" + config.uuid
         config.dbName = dbNameConstructed
     }
     config.mysqlPath = config.mysqlPath ?: '/usr/bin/mysql'

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -20,9 +20,8 @@ def call(Closure body) {
     body()
     String uuid = UUID.randomUUID()
     config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
-    environment {
-        MYSQL_UUID = config.uuid
-    }
+    env.MYSQL_UUID = config.uuid
+
     // Set any unprovided configuration values to defaults
     // Set any unprovided configuration to random generated.
     if (config.dbName == null || config.dbName == '') {

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -19,12 +19,12 @@ def call(Closure body) {
     body.delegate = config
     body()
     String uuid = UUID.randomUUID()
-    def modifieduuid = uuid.replaceAll('-','_')
+    config.uuid  = uuid.replaceAll('-','_')
 
     // Set any unprovided configuration values to defaults
     // Set any unprovided configuration to random generated.
     if (config.dbName == null || config.dbName == '') {
-        String dbNameConstructed = "testdb_" + modifieduuid + "_" + env.BUILD_NUMBER
+        String dbNameConstructed = "testdb_" + config.uuid + "_" + env.BUILD_NUMBER
         config.dbName = dbNameConstructed
     }
     config.mysqlPath = config.mysqlPath ?: '/usr/bin/mysql'

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -20,7 +20,9 @@ def call(Closure body) {
     body()
     String uuid = UUID.randomUUID()
     config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
-
+    environment {
+        MYSQL_UUID = config.uuid
+    }
     // Set any unprovided configuration values to defaults
     // Set any unprovided configuration to random generated.
     if (config.dbName == null || config.dbName == '') {

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -18,17 +18,19 @@ def call(Closure body) {
     body.resolveStrategy = Closure.DELEGATE_FIRST
     body.delegate = config
     body()
-    String uuid = UUID.randomUUID()
-    config.uuid  = uuid.replaceAll('-','_') + "_" + env.BUILD_NUMBER
-    if (env.MYSQL_UUID == null || env.MYSQL_UUID == '') {
-        env.MYSQL_UUID = config.uuid
-    }
+
     // Set any unprovided configuration values to defaults
     // Set any unprovided configuration to random generated.
     if (config.dbName == null || config.dbName == '') {
         String dbNameConstructed = "testdb_" + env.MYSQL_UUID
         config.dbName = dbNameConstructed
     }
+
+    // Set newDB variable to true if not specified.
+    if (config.newDB == null | config.newDB == '') {
+        config.newDB = true
+    }
+
     config.mysqlPath = config.mysqlPath ?: '/usr/bin/mysql'
     config.mysqlPort = config.mysqlPort ?: 3306
     

--- a/vars/evaluateMySQLDatabaseConfiguration.groovy
+++ b/vars/evaluateMySQLDatabaseConfiguration.groovy
@@ -18,9 +18,15 @@ def call(Closure body) {
     body.resolveStrategy = Closure.DELEGATE_FIRST
     body.delegate = config
     body()
-    
+    String uuid = UUID.randomUUID()
+    def modifieduuid = uuid.replaceAll('-','_')
+
     // Set any unprovided configuration values to defaults
-    config.dbName = config.dbName ?: "testdb_${env.BUILD_NUMBER}"
+    // Set any unprovided configuration to random generated.
+    if (dbName == null || dbName == '') {
+        String dbNameConstructed = "testdb_" + modifieduuid + "_" + env.BUILD_NUMBER
+        config.dbName = dbNameConstructed
+    }
     config.mysqlPath = config.mysqlPath ?: '/usr/bin/mysql'
     config.mysqlPort = config.mysqlPort ?: 3306
     


### PR DESCRIPTION
I began using your library; however, there is a limitation in that everything is tied to the build number. If you need multiple databases per build that are separate this is a problem. I started modifying the code to allow for randomly generated database names, users, and password based off a single UUID.

Your repository is one of the top hits on Google for MySQL shared libraries so I thought this would be a worthwhile contribution. I will continue to improve the library as I also started to remove the body closures as parameters as they are not best practice and make debugging rather difficult.